### PR TITLE
Compile time flag helper

### DIFF
--- a/src/estd/flags.h
+++ b/src/estd/flags.h
@@ -34,7 +34,7 @@ public:
 
     constexpr flags(const value_type& value) : value_{value}    {}
 
-    constexpr flags& operator|=(const flags& v)
+    ESTD_CPP_CONSTEXPR(14) flags& operator|=(const flags& v)
     {
         value_ |= v;
         return *this;

--- a/src/estd/flags.h
+++ b/src/estd/flags.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <estd/internal/type_traits.h>
+
+#include "internal/fwd/flags.h"
+
+namespace estd { namespace detail { inline namespace v1 {
+
+///
+/// \brief The flags class
+///
+template <class Enum>
+class flags
+{
+public:
+#if FEATURE_ESTD_UNDERLYING_TYPE
+    using int_type = typename estd::underlying_type<Enum>::type;
+#else
+    using int_type = int;
+#endif
+
+    using value_type = Enum;
+
+private:
+    value_type value_;
+
+    // Force int conversion to always fail, we don't want 'bool' conversion to fool us in these cases
+    //constexpr operator int_type() const { return value_; }
+
+public:
+    constexpr explicit flags(int_type v) :
+        value_{value_type(v)}
+    {}
+
+    constexpr flags(const value_type& value) : value_{value}    {}
+
+    constexpr flags& operator|=(const flags& v)
+    {
+        value_ |= v;
+        return *this;
+    }
+
+    constexpr operator value_type() const { return value_; }
+
+    constexpr operator bool() const { return value_ != value_type{}; }
+
+    constexpr value_type value() const { return value_; }
+
+    // Putting these all as members instead of freestanding operators for easy access to int_type
+
+    constexpr flags operator~() const
+    {
+        return flags(~int_type(value_));
+    }
+
+    constexpr flags operator ^(const value_type& v) const
+    {
+        return flags{int_type(v) ^ int_type(value_)};
+    }
+
+    constexpr flags operator |(const value_type& v) const
+    {
+        return flags{int_type(v) ^ int_type(value_)};
+    }
+
+    constexpr flags operator &(const value_type& v) const
+    {
+        return flags{int_type(v) & int_type(value_)};
+    }
+};
+
+
+template <class Enum>
+constexpr bool operator==(const flags<Enum>& lhs, const Enum& rhs)
+{
+    return lhs.value() == rhs;
+}
+
+
+template <class Enum>
+constexpr bool operator==(const flags<Enum>& lhs, const flags<Enum>& rhs)
+{
+    return lhs.value() == rhs.value();
+}
+
+template <class Enum>
+constexpr bool operator!=(const flags<Enum>& lhs, const flags<Enum>& rhs)
+{
+    return lhs.value() != rhs.value();
+}
+
+
+}}}
+
+
+// Auto-promotes 'Enum' to flags<Enum> during these operations
+#define ESTD_FLAGS(Enum)    \
+constexpr estd::detail::v1::flags<Enum> operator~(const Enum& v)    \
+{ return ~estd::detail::v1::flags<Enum>(v); }     \
+    constexpr estd::detail::v1::flags<Enum> operator^(const Enum& lhs, const Enum& rhs)    \
+{ return estd::detail::v1::flags<Enum>(lhs) ^ rhs; }     \
+    constexpr estd::detail::v1::flags<Enum> operator|(const Enum& lhs, const Enum& rhs)    \
+{ return estd::detail::v1::flags<Enum>(lhs) | rhs; }     \
+    constexpr embr::v1::flags<Enum> operator&(const Enum& lhs, const Enum& rhs)    \
+{ return estd::detail::v1::flags<Enum>(lhs) & rhs; }
+

--- a/src/estd/flags.h
+++ b/src/estd/flags.h
@@ -7,7 +7,7 @@
 namespace estd { namespace detail { inline namespace v1 {
 
 ///
-/// \brief The flags class
+/// Designed really to be fully consteval friendly, but works as intended merely as contextp
 ///
 template <class Enum>
 class flags
@@ -101,6 +101,6 @@ constexpr estd::detail::v1::flags<Enum> operator~(const Enum& v)    \
 { return estd::detail::v1::flags<Enum>(lhs) ^ rhs; }     \
     constexpr estd::detail::v1::flags<Enum> operator|(const Enum& lhs, const Enum& rhs)    \
 { return estd::detail::v1::flags<Enum>(lhs) | rhs; }     \
-    constexpr embr::v1::flags<Enum> operator&(const Enum& lhs, const Enum& rhs)    \
+    constexpr estd::detail::v1::flags<Enum> operator&(const Enum& lhs, const Enum& rhs)    \
 { return estd::detail::v1::flags<Enum>(lhs) & rhs; }
 

--- a/src/estd/internal/feature/type_traits.h
+++ b/src/estd/internal/feature/type_traits.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../platform.h"
+#include "../feature/std.h"
 
 // By default, if available, we alias a bunch of type_traits stuff to its underlying
 // std.  This can be turned off to use a subset of our own implementation which is

--- a/src/estd/internal/fwd/flags.h
+++ b/src/estd/internal/fwd/flags.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#pragma once
+
+namespace estd { namespace detail { inline namespace v1 {
+
+template <class Enum>
+class flags;
+
+}}}

--- a/src/estd/internal/macro/c++/attr.h
+++ b/src/estd/internal/macro/c++/attr.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// NOTE: Not using feature test has_macro since I've seen that glitch
+// out in llvm IIRC
+#if __cplusplus >= 201703L
+#define ESTD_CPP_ATTR_FALLTHROUGH   [[fallthrough]]
+#define ESTD_CPP_ATTR_NODISCARD     [[nodiscard]]
+#else
+#define ESTD_CPP_ATTR_FALLTHROUGH
+#define ESTD_CPP_ATTR_NODISCARD
+#endif

--- a/src/estd/internal/macro/c++/const.h
+++ b/src/estd/internal/macro/c++/const.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Take pages out of GCC playbook
+#if __cplusplus >= 202002L
+#define ESTD_CPP20_CONSTEXPR constexpr
+#else
+#define ESTD_CPP20_CONSTEXPR
+#endif
+
+#if __cplusplus >= 201703L
+#define ESTD_CPP17_CONSTEXPR constexpr
+#else
+#define ESTD_CPP17_CONSTEXPR
+#endif
+
+#if __cplusplus >= 201402L
+#define ESTD_CPP14_CONSTEXPR constexpr
+#else
+#define ESTD_CPP14_CONSTEXPR
+#endif
+
+#if __cplusplus >= 201103L
+#define ESTD_CPP11_CONSTEXPR constexpr
+#else
+#define ESTD_CPP11_CONSTEXPR
+#endif
+
+#define ESTD_CPP_CONSTEXPR(v)    ESTD_CPP ## v ## _CONSTEXPR
+
+// 23FEB25 MB DEBT: Inconsistency between ESTD_CPP_ prefix and lack of prefix
+#ifdef __cpp_conditional_explicit
+#define CONSTEXPR_EXPLICIT(conditional) constexpr explicit(conditional)
+#elif __cpp_constexpr
+#define CONSTEXPR_EXPLICIT(conditional) constexpr explicit
+#else
+#define CONSTEXPR_EXPLICIT(conditional) inline
+#endif
+

--- a/src/estd/internal/macro/c++/ctor.h
+++ b/src/estd/internal/macro/c++/ctor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Remember, initializer_lists are not forwarded!
+// https://stackoverflow.com/questions/28370970/forwarding-initializer-list-expressions
+#if defined(__cpp_variadic_templates) && defined(__cpp_rvalue_references)
+#define ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, member)    \
+    template <class ...FwdArgs>                   \
+    explicit constexpr class_name(FwdArgs&&...args) :      \
+        member(std::forward<FwdArgs>(args)...) \
+    {}
+#else
+#define ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, member)    \
+    template <class TParam1>                    \
+    class_name(const TParam1& p1) :             \
+        member(p1) {}
+#endif
+
+#define ESTD_CPP_FORWARDING_CTOR(class_name)    ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, base_type)
+
+#if __cpp_initializer_lists
+#define ESTD_CPP_FORWARDING_CTOR_LIST(T, class_name)    \
+    class_name(std::initializer_list<T> list) : base_type(list) {}
+#else
+#define ESTD_CPP_FORWARDING_CTOR_LIST(T, class_name)
+#endif

--- a/src/estd/internal/macro/c++11_emul.h
+++ b/src/estd/internal/macro/c++11_emul.h
@@ -2,58 +2,14 @@
 
 #pragma once
 
-// Remember, initializer_lists are not forwarded!
-// https://stackoverflow.com/questions/28370970/forwarding-initializer-list-expressions
-#if defined(__cpp_variadic_templates) && defined(__cpp_rvalue_references)
-#define ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, member)    \
-    template <class ...FwdArgs>                   \
-    explicit constexpr class_name(FwdArgs&&...args) :      \
-        member(std::forward<FwdArgs>(args)...) \
-    {}
-#else
-#define ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, member)    \
-    template <class TParam1>                    \
-    class_name(const TParam1& p1) :             \
-        member(p1) {}
-#endif
-
-#define ESTD_CPP_FORWARDING_CTOR(class_name)    ESTD_CPP_FORWARDING_CTOR_MEMBER(class_name, base_type)
-
-#if __cpp_initializer_lists
-#define ESTD_CPP_FORWARDING_CTOR_LIST(T, class_name)    \
-    class_name(std::initializer_list<T> list) : base_type(list) {}
-#else
-#define ESTD_CPP_FORWARDING_CTOR_LIST(T, class_name)
-#endif
+#include "c++/ctor.h"
+#include "c++/const.h"
 
 #if __cpp_constexpr
 #define ESTD_CPP_CONSTEXPR_RET constexpr
 #else
 #define ESTD_CPP_CONSTEXPR_RET inline
 #endif
-
-// Take pages out of GCC playbook
-// DEBT: These belong elsewhere, not in c++_emul per se
-#if __cplusplus >= 202002L
-#define ESTD_CPP20_CONSTEXPR constexpr
-#else
-#define ESTD_CPP20_CONSTEXPR
-#endif
-
-#if __cplusplus >= 201703L
-#define ESTD_CPP17_CONSTEXPR constexpr
-#else
-#define ESTD_CPP17_CONSTEXPR
-#endif
-
-#if __cplusplus >= 201402L
-#define ESTD_CPP14_CONSTEXPR constexpr
-#else
-#define ESTD_CPP14_CONSTEXPR
-#endif
-
-
-#define ESTD_CPP_CONSTEXPR(v)    ESTD_CPP ## v ## _CONSTEXPR
 
 #if __cpp_ref_qualifiers
 #define ESTD_CPP_REFQ &

--- a/src/estd/internal/macro/cpp.h
+++ b/src/estd/internal/macro/cpp.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "c++/attr.h"
+
 // NOTE: Only applies to empty constructor.  You're on your own for the "more complex" varieties
 #ifdef FEATURE_CPP_DEFAULT_CTOR
 #define ESTD_CPP_DEFAULT_CTOR(class_name)   constexpr class_name() = default;
@@ -15,12 +17,3 @@
     typedef value_type* pointer;                \
     typedef const value_type* const_pointer;
 
-// NOTE: Not using feature test has_macro since I've seen that glitch
-// out in llvm IIRC
-#if __cplusplus >= 201703L
-#define ESTD_CPP_ATTR_FALLTHROUGH   [[fallthrough]]
-#define ESTD_CPP_ATTR_NODISCARD     [[nodiscard]]
-#else
-#define ESTD_CPP_ATTR_FALLTHROUGH
-#define ESTD_CPP_ATTR_NODISCARD
-#endif

--- a/src/estd/internal/macros.h
+++ b/src/estd/internal/macros.h
@@ -5,6 +5,9 @@
 #include "feature/std.h"
 #include "feature/cpp.h"
 #include "macro/c++11_emul.h"
+#include "macro/c++/attr.h"
+#include "macro/c++/ctor.h"
+#include "macro/c++/const.h"
 #include "macro/cpp.h"
 
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
@@ -31,14 +34,6 @@
 #else
 #define CONSTEXPR const
 #define EXPLICIT
-#endif
-
-#ifdef __cpp_conditional_explicit
-#define CONSTEXPR_EXPLICIT(conditional) constexpr explicit(conditional)
-#elif __cpp_constexpr
-#define CONSTEXPR_EXPLICIT(conditional) constexpr explicit
-#else
-#define CONSTEXPR_EXPLICIT(conditional) inline
 #endif
 
 #ifdef FEATURE_CPP_NOEXCEPT

--- a/src/estd/internal/type_traits.h
+++ b/src/estd/internal/type_traits.h
@@ -19,6 +19,7 @@
 #include "type_traits/is_convertible.h"
 #include "type_traits/is_member.h"
 #include "type_traits/make_unsigned.h"
+#include "type_traits/is_trivial.h"
 
 
 #include "../port/support_platform.h"

--- a/src/estd/internal/type_traits/is_trivial.h
+++ b/src/estd/internal/type_traits/is_trivial.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "features.h"
+
+#if FEATURE_ESTD_TYPE_TRAITS_ALIASED
+#include <type_traits>
+
+namespace estd {
+
+template <typename T>
+using underlying_type = std::underlying_type<T>;
+
+template <typename T>
+using is_trivial = std::is_trivial<T>;
+
+#define FEATURE_ESTD_UNDERLYING_TYPE 1
+#define FEATURE_ESTD_IS_TRIVIAL 1
+
+}
+#endif

--- a/src/estd/port/gcc/type_traits.h
+++ b/src/estd/port/gcc/type_traits.h
@@ -1,17 +1,20 @@
 #pragma once
 
+#include "../../internal/feature/std.h"
+
 // TODO: Check compiler version to ensure we indeed can support this
 
+#if !FEATURE_ESTD_TYPE_TRAITS_ALIASED
 namespace estd {
 
 /// The underlying type of an enum.
-template<typename T>
+template <typename T>
 struct underlying_type
 {
     typedef __underlying_type(T) type;
 };
 
-template<typename _Tp>
+template <typename _Tp>
 struct is_trivial
     : public integral_constant<bool, __is_trivial(_Tp)>
 { };
@@ -20,3 +23,4 @@ struct is_trivial
 #define FEATURE_ESTD_IS_TRIVIAL 1
 
 }
+#endif

--- a/test/catch/CMakeLists.txt
+++ b/test/catch/CMakeLists.txt
@@ -61,6 +61,7 @@ else()
         chrono-test.cpp
         cstddef-test.cpp
         dynamic-array-test.cpp
+        flags-test.cpp
         experimental/memory-pool1-test.cpp
         experimental/memory-pool2-test.cpp
         experimental/memory-pool3-test.cpp

--- a/test/catch/algorithm-test.cpp
+++ b/test/catch/algorithm-test.cpp
@@ -21,7 +21,7 @@ using namespace estd;
 
 TEST_CASE("algorithm tests")
 {
-    test_class_1 tc1;
+    //test_class_1 tc1;
 
     SECTION("find_if in class")
     {

--- a/test/catch/flags-test.cpp
+++ b/test/catch/flags-test.cpp
@@ -2,6 +2,37 @@
 
 #include <estd/flags.h>
 
+enum synthetic_flags
+{
+    SN_NONE = 0x00,
+    SN_CONST = 0x01,
+    SN_DOUBLE = 0x02
+};
+
+ESTD_FLAGS(synthetic_flags)
+
+template <synthetic_flags, class = void>
+struct test1
+{
+    using value_type = int;
+};
+
+
+template <synthetic_flags f>
+struct test1<f, estd::enable_if_t<f & SN_DOUBLE>>
+{
+    static constexpr bool is_const = f & SN_CONST;
+    using value_type = double;
+};
+
+
 TEST_CASE("flags (compile-time capable)", "[flags]")
 {
+    using t1 = test1<SN_NONE>;
+    using t2 = test1<SN_DOUBLE>;
+    using t3 = test1<SN_DOUBLE | SN_CONST>;
+
+    static_assert(std::is_same<t1::value_type, int>::value, "");
+    static_assert(std::is_same<t2::value_type, double>::value, "");
+    static_assert(t3::is_const, "");
 }

--- a/test/catch/flags-test.cpp
+++ b/test/catch/flags-test.cpp
@@ -1,0 +1,7 @@
+#include <catch2/catch.hpp>
+
+#include <estd/flags.h>
+
+TEST_CASE("flags (compile-time capable)", "[flags]")
+{
+}

--- a/test/rtos/esp32/README.md
+++ b/test/rtos/esp32/README.md
@@ -19,6 +19,7 @@ These tests are all for variants of Espressif ESP32
 | 20JUL23 | ios      | ESP32 Lolin Generic  | ESP32          | v5.0.3   | Pass   |
 | 19DEC23 | ios      | WaveShare C6-DevKit  | ESP32C6        | v5.1.2   | Pass   |
 | 02MAR24 | ios      | Seeed Xiao           | ESP32S3        | v5.1.3   | Pass   |
+| 22FEB25 | ios      | QEMU                 | ESP32S3        | v5.3.2   | Pass   |
 | 07DEC22 | timer    | ESP-WROVER-KIT v4.1  | ESP32-WROVER-E | v4.4.3   | Pass   |
 | 15JUN23 | timer    | ESP32-C3-DevKitM-1   | ESP32C3        | v5.0.2   | Pass   |
 | 07DEC22 | unity    | ESP-WROVER-KIT v4.1  | ESP32-WROVER-E | v4.4.3   | Pass   |


### PR DESCRIPTION
Adapter and imported from `embr`, this provides `ESTD_FLAGS` macro.

This macro effectively upgrades your enum to be more constexpr/bitwise logic friendly so that you can more comfortably use it during specialization.  See Catch2 tests for more details